### PR TITLE
Add camera zoom

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - spec/mocks.rb
 
 Layout/ArgumentAlignment:
-  EnforcedStyle: with_fixed_indentation
+  Enabled: false
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ There are sample apps included. They are:
                     forth along the ground. It demonstrates external sprite
                     camera tracking and parallax.
  * **RPG** - A sample [Pipoya](https://pipoya.itch.io/pipoya-rpg-tileset-32x32)
-             map. Demonstrates camera panning.
+             map. Demonstrates camera panning and zoom.
 
 To use the sample apps, put the root of this repo into an empty `mygame`
 directory in a freshly unzipped DragonRuby project. You will need to install

--- a/app/rpg.rb
+++ b/app/rpg.rb
@@ -29,11 +29,11 @@ class RPG
     end
 
     if @args.inputs.keyboard.key_held.q
-      @renderer.camera.zoom_out 0.05
+      @renderer.camera.zoom_out 0.01
     end
 
     if @args.inputs.keyboard.key_held.e
-      @renderer.camera.zoom_in 0.05
+      @renderer.camera.zoom_in 0.01
     end
 
     @renderer.render_map

--- a/app/rpg.rb
+++ b/app/rpg.rb
@@ -28,6 +28,14 @@ class RPG
       end
     end
 
+    if @args.inputs.keyboard.key_held.q
+      @renderer.camera.zoom_out 0.05
+    end
+
+    if @args.inputs.keyboard.key_held.e
+      @renderer.camera.zoom_in 0.05
+    end
+
     @renderer.render_map
   end
 end

--- a/lib/tiled_renderer/camera.rb
+++ b/lib/tiled_renderer/camera.rb
@@ -2,21 +2,32 @@ module Tiled
   # Controller for a camera which moves around the map. It points to the pixel on the map
   # that is rendered to the lower-left pixel of the screen.
   class Camera
-    attr_accessor :position, :zoom
+    attr_reader :rect, :zoom
 
     def initialize(args, map)
       @args = args
       @map = map
 
-      @position = [map.properties[:camera_origin_x] || 0, map.properties[:camera_origin_y] || 0]
+      @screen_width = args.grid.w.to_f
+      @screen_height = args.grid.h.to_f
+
+      # The camera is represented internally as a rectangle overlayed on the map
+      @rect = [
+        map.properties[:camera_origin_x] || 0,
+        map.properties[:camera_origin_y] || 0,
+        map.properties[:camera_origin_w] || @screen_width,
+        map.properties[:camera_origin_h] || @screen_height
+      ]
+
       @zoom = 1
-      @zoom_offset = [0, 0]
+      @min_zoom = nil
+      @max_zoom = nil
 
-      @screen_width = args.grid.w
-      @screen_height = args.grid.h
+      @map_width = map.pixelwidth
+      @map_height = map.pixelheight
 
-      @map_width = @map_render_w = map.pixelwidth
-      @map_height = @map_render_h = map.pixelheight
+      @render_width = @map_width
+      @render_height = @map_height
 
       # The camera "deadzone" around the center is actually calculated
       # as a "margin" around the edges internally.
@@ -25,59 +36,127 @@ module Tiled
       set_deadzone up: 0, down: default, left: default, right: default
     end
 
+    # @return [Float] the map X-coordinate of the camera
     def x
-      position.x
+      rect.x
     end
 
+    # @param value [Numeric] map X-coordinate to set
     def x=(value)
-      position.x = value
+      rect.x = value
     end
 
+    # @return [Float] the map Y-coordinate of the camera
     def y
-      position.y
+      rect.y
     end
 
+    # @param value [Numeric] map Y-coordinate to set
     def y=(value)
-      position.y = value
+      rect.y = value
     end
 
-    def zoom_in(amount)
-      @zoom += amount
+    # @return [Array] the map coordinates of the lower-left corner of the camera
+    def position
+      [rect.x, rect.y]
     end
 
-    def zoom_out(amount)
-      @zoom -= amount
+    # @param point [Array] the map coordinates to set the camera to
+    def position=(point)
+      rect.x = point.x
+      rect.y = point.y
     end
 
-    # @return [Hash] the camera-adjusted x, y, w, and h positioning of the map
-    def map_xywh
-      aspect_ratio = @map.pixelwidth.to_f / @map.pixelheight.to_f
-
-      @map_render_w = (@map.pixelwidth * zoom).to_f
-      @map_render_h = (@map.pixelheight * zoom).to_f
-
-      if aspect_ratio > 1.0
-        # Landscape
-        @map_render_w = @map_render_h * aspect_ratio
-      else
-        # Portrait
-        @map_render_h = @map_render_w / aspect_ratio
+    # Pans the camera around the map. Will not pan past the edges
+    # of the map. You can pass in either X, Y, or both.
+    #
+    # @option :x [Numeric] the amount to pan on the X-axis
+    # @option :y [Numeric] the amount to pan on the Y-axis
+    def pan(x: nil, y: nil)
+      if x
+        @rect.x = [
+          0,
+          @rect.x + x,
+          @map_width - @rect.w
+        ].sort[1]
       end
 
-      # Calculate the offset required to keep the camera centered, and
-      # save it so we know where the outer bounds of the map are for
-      # camera panning
-      @zoom_offset = [
-        ((@map_render_w - @map_width) * (@screen_width + (2 * position.x))) / (2 * @map_width),
-        ((@map_render_h - @map_height) * (@screen_height + (2 * position.y))) / (2 * @map_height)
-      ]
+      if y
+        @rect.y = [
+          0,
+          @rect.y + y,
+          @map_height - @rect.h
+        ].sort[1]
+      end
+    end
 
+    alias move pan
+
+    # Sets zoom. Zoom is a value > 0 that is used as a scale amount. For example,
+    # if zoom is set to 2, objects will appear twice as large as they did at zoom 1.
+    #
+    # @param value [Numeric] the value to set the zoom to
+    def zoom=(value)
+      @zoom = value
+      calculate_zoom
+    end
+
+    # @param amount [Numeric] the amount to increase the zoom by
+    def zoom_in(amount)
+      if @max_zoom && zoom + amount > @max_zoom
+        @zoom = @max_zoom
+      else
+        @zoom += amount
+      end
+
+      calculate_zoom
+    end
+
+    # Zooms the camera out. Will not zoom out to reveal past the edges of the map.
+    # If up against only one edge, the camera will zoom out but will not be able
+    # to remain centered and will stay butted up against the edge.
+    #
+    # @param amount [Numeric] the amount to decrease the zoom by
+    def zoom_out(amount)
+      orig_zoom = @zoom
+
+      if @min_zoom && zoom - amount < @min_zoom
+        @zoom = @min_zoom
+      else
+        @zoom -= amount
+      end
+
+      calculate_zoom
+
+      # Roll back if we've zoomed out of bounds of the map
+      if @rect.w >= @map_width || @rect.h >= @map_height
+        @zoom = orig_zoom
+        calculate_zoom
+      end
+    end
+
+    # Gets the X, Y, width, and height to render a layer/map at based on
+    # the camera's zoom and positioning.
+    #
+    # @param parallax [Array] the parallax value of the layer
+    # @return [Hash] the camera-adjusted x, y, w, and h positioning of the layer
+    def render_rect(parallax=[1, 1])
       {
-        x: -(x + @zoom_offset.x), y: -(y + @zoom_offset.y),
-        w: @map_render_w, h: @map_render_h
+        x: -(@render_width / @map_width) * (@rect.x * parallax.x),
+        y: -(@render_height / @map_height) * (@rect.y * parallax.y),
+        w: @render_width,
+        h: @render_height
       }
     end
 
+    # Sets the "deadzone" in the middle of the camera around which the player
+    # may move freely without disturbing the position of the camera if using
+    # `#track` to follow an external primitive. You may set any or all directons.
+    #
+    # #option up [Numeric] the deadzone's height above the center
+    # #option down [Numeric] the deadzone's height below the center
+    # #option left [Numeric] the deadzone's width left of the center
+    # #option right [Numeric] the deadzone's width right of the center
     def set_deadzone(up: nil, down: nil, left: nil, right: nil)
       { @screen_height => %i[up down], @screen_width => %i[left right] }.each do |size, dirs|
         midpoint = size / 2.0
@@ -91,44 +170,62 @@ module Tiled
       end
     end
 
-    def move(x: nil, y: nil)
-      if x
-        @position.x = [
-          -@zoom_offset.x,
-          @position.x + x,
-          # (@map_render_w - ((@map_render_w * @screen_width) / @map_width))
-          (@position.x + @zoom_offset.x) * (@map_width / @map_render_w)
-        ].sort[1]
-      end
+    # Adjust the camera's position to keep `target` within the deadzone.
+    #
+    # @param target [Array || Hash] a rectangle with x, y, w, and h
+    def track(target)
+      x, y, w, h = target.is_a?(Hash) ? [target.x, target.y, target.w, target.h] : target
 
-      if y
-        @position.y = [
-          -@zoom_offset.y,
-          @position.y + y,
-          @map_height - @screen_height + @zoom_offset.y
-        ].sort[1]
-      end
-    end
-
-    def track(rect)
-      x, y, w, h = rect.is_a?(Hash) ? [rect.x, rect.y, rect.w, rect.h] : rect
-
-      screen_position = [x - @position.x, y - @position.y]
+      screen_position = [x - @rect.x, y - @rect.y]
       opposite = [screen_position.x + w, screen_position.y + h]
+
+      # TODO: Stop this from calling #pan if camera is at outer edge of screen
 
       right_x = @screen_width - @margin[:right]
       if opposite.x > right_x
-        move x: opposite.x - right_x
+        pan x: opposite.x - right_x
       elsif screen_position.x < @margin[:left]
-        move x: screen_position.x - @margin[:left]
+        pan x: screen_position.x - @margin[:left]
       end
 
       top_y = @screen_height - @margin[:up]
       if opposite.y > top_y
-        move y: opposite.y - top_y
+        pan y: opposite.y - top_y
       elsif screen_position.y < @margin[:down]
-        move y: screen_position.y - @margin[:down]
+        pan y: screen_position.y - @margin[:down]
       end
+    end
+
+    private
+
+    # This needs to run every time zoom changes.
+    def calculate_zoom
+      aspect_ratio = @screen_width / @screen_height
+
+      # Zoom needs to be reflected about 1 because increasing zoom
+      # actually needs to decrease the size of the rectangle
+      scale_factor = zoom > 0 ? 1 + (1 - Math.sqrt(zoom)) : 0
+
+      orig_width, orig_height = @rect.w, @rect.h
+
+      @rect.w = @screen_width * scale_factor
+      @rect.h = @screen_height * scale_factor
+
+      if aspect_ratio > 1.0
+        # Landscape
+        @rect.w = @rect.h * aspect_ratio
+      else
+        # Portrait
+        @rect.h = @rect.w / aspect_ratio
+      end
+
+      # Scale the map's render width according to the zoom
+      @render_width = (@screen_width / @rect.w) * @map_width
+      @render_height = (@screen_height / @rect.h) * @map_height
+
+      # #pan handles edge collisions
+      pan x: (orig_width - @rect.w) / 2,
+          y: (orig_height - @rect.h) / 2
     end
   end
 end

--- a/lib/tiled_renderer/camera.rb
+++ b/lib/tiled_renderer/camera.rb
@@ -2,16 +2,21 @@ module Tiled
   # Controller for a camera which moves around the map. It points to the pixel on the map
   # that is rendered to the lower-left pixel of the screen.
   class Camera
-    attr_accessor :position
+    attr_accessor :position, :zoom
 
     def initialize(args, map)
       @args = args
       @map = map
 
       @position = [map.properties[:camera_origin_x] || 0, map.properties[:camera_origin_y] || 0]
+      @zoom = 1
+      @zoom_offset = [0, 0]
 
       @screen_width = args.grid.w
       @screen_height = args.grid.h
+
+      @map_width = @map_render_w = map.pixelwidth
+      @map_height = @map_render_h = map.pixelheight
 
       # The camera "deadzone" around the center is actually calculated
       # as a "margin" around the edges internally.
@@ -24,8 +29,53 @@ module Tiled
       position.x
     end
 
+    def x=(value)
+      position.x = value
+    end
+
     def y
       position.y
+    end
+
+    def y=(value)
+      position.y = value
+    end
+
+    def zoom_in(amount)
+      @zoom += amount
+    end
+
+    def zoom_out(amount)
+      @zoom -= amount
+    end
+
+    # @return [Hash] the camera-adjusted x, y, w, and h positioning of the map
+    def map_xywh
+      aspect_ratio = @map.pixelwidth.to_f / @map.pixelheight.to_f
+
+      @map_render_w = (@map.pixelwidth * zoom).to_f
+      @map_render_h = (@map.pixelheight * zoom).to_f
+
+      if aspect_ratio > 1.0
+        # Landscape
+        @map_render_w = @map_render_h * aspect_ratio
+      else
+        # Portrait
+        @map_render_h = @map_render_w / aspect_ratio
+      end
+
+      # Calculate the offset required to keep the camera centered, and
+      # save it so we know where the outer bounds of the map are for
+      # camera panning
+      @zoom_offset = [
+        ((@map_render_w - @map_width) * (@screen_width + (2 * position.x))) / (2 * @map_width),
+        ((@map_render_h - @map_height) * (@screen_height + (2 * position.y))) / (2 * @map_height)
+      ]
+
+      {
+        x: -(x + @zoom_offset.x), y: -(y + @zoom_offset.y),
+        w: @map_render_w, h: @map_render_h
+      }
     end
 
     def set_deadzone(up: nil, down: nil, left: nil, right: nil)
@@ -43,11 +93,20 @@ module Tiled
 
     def move(x: nil, y: nil)
       if x
-        @position.x = [0, @position.x + x, (@map.width * @map.tilewidth) - @screen_width].sort[1]
+        @position.x = [
+          -@zoom_offset.x,
+          @position.x + x,
+          # (@map_render_w - ((@map_render_w * @screen_width) / @map_width))
+          (@position.x + @zoom_offset.x) * (@map_width / @map_render_w)
+        ].sort[1]
       end
 
       if y
-        @position.y = [0, @position.y + y, (@map.height * @map.tileheight) - @screen_height].sort[1]
+        @position.y = [
+          -@zoom_offset.y,
+          @position.y + y,
+          @map_height - @screen_height + @zoom_offset.y
+        ].sort[1]
       end
     end
 

--- a/lib/tiled_renderer/renderer.rb
+++ b/lib/tiled_renderer/renderer.rb
@@ -22,27 +22,36 @@ module Tiled
       cache_layers
     end
 
+    # Changes the map and initializes a new camera.
+    #
+    # @param map [Tiled::Map] the map to switch to
+    # @return [Tiled::Camera] the newly initialized camera
     def map=(map)
       @map = map
       @camera = Camera.new(@args, map)
     end
 
+    # Renders a primitive onto the map, accounting for camera position.
     def render_primitive(primitive, target=:primitives)
+      # TODO: Account for zoom, allow layering
+
       @args.outputs.send(target) << primitive.dup.tap do |p|
         p.x -= @camera.x
         p.y -= @camera.y
       end
     end
 
+    # Renders a layer of the map.
+    #
+    # @param layer [Tiled::Layer || Tiled::ObjectLayer] the layer to render
+    # @param target [Symbol || GTK::OutputsArray] the output target
     def render_layer(layer, target=:primitives)
       layer = map.layers[layer.to_s] unless [Layer, ObjectLayer].any? { |cls| layer.is_a? cls }
       return unless layer&.visible?
 
       target = @args.outputs.send(target) if target.is_a?(Symbol)
 
-      layer_camera = [@camera.x * layer.parallax.x, @camera.y, layer.parallax.y]
-
-      primitives = [{ **camera.map_xywh, path: :"map_layer_#{layer.id}" }]
+      primitives = [{ **camera.render_rect(layer.parallax), path: :"map_layer_#{layer.id}" }]
 
       # Re-render all animated sprites
       if layer.animated_sprites.any?
@@ -53,6 +62,9 @@ module Tiled
       target << primitives
     end
 
+    # Renders the entire map.
+    #
+    # @param target [Symbol || GTK::OutputsArray] the output target
     def render_map(target=:primitives)
       map.layers.each { |layer| render_layer(layer, target) }
     end

--- a/lib/tiled_renderer/renderer.rb
+++ b/lib/tiled_renderer/renderer.rb
@@ -42,11 +42,7 @@ module Tiled
 
       layer_camera = [@camera.x * layer.parallax.x, @camera.y, layer.parallax.y]
 
-      primitives = [{
-        x: -layer_camera.x, y: -layer_camera.y,
-        w: @map.pixelwidth, h: @map.pixelheight,
-        path: :"map_layer_#{layer.id}"
-      }]
+      primitives = [{ **camera.map_xywh, path: :"map_layer_#{layer.id}" }]
 
       # Re-render all animated sprites
       if layer.animated_sprites.any?

--- a/spec/tiled_renderer/renderer_spec.rb
+++ b/spec/tiled_renderer/renderer_spec.rb
@@ -21,7 +21,7 @@ describe Tiled::Renderer do
       end
 
       it "resets the camera" do
-        renderer.camera.move x: 10
+        renderer.camera.pan x: 10
         renderer.map = Tiled::Map.new("spec/maps/test2.tmx").tap(&:load)
 
         expect(renderer.camera.x).to eq 0
@@ -34,7 +34,7 @@ describe Tiled::Renderer do
       %i[x y].each do |dir|
         it "subtracts the camera's #{dir} position from the primitive" do
           other = (%i[x y] - [dir]).first
-          renderer.camera.move dir => 10
+          renderer.camera.pan dir => 10
           expect_any_instance_of(OutputsArrayMock).
             to receive(:<<).with({ dir => 0, other => 10, w: 10, h: 10 })
 
@@ -98,49 +98,14 @@ describe Tiled::Renderer do
       end
 
       context "when the camera position has been adjusted" do
-        before { renderer.camera.zoom }
+        before { renderer.camera.pan x: 50, y: 50 }
 
+        # Verify that camera's behavior is being passed through to the
+        # renderer; see camera_spec.rb for more detailed zoom specs.
         it "draws the layer as a map-sized sprite" do
-          expect_output(array_including(hash_including(
-            x: -renderer.camera.x, y: -renderer.camera.y,
-            w: map.pixelwidth, h: map.pixelheight, path: :"map_layer_#{layer.id}"
-          )))
-        end
-      end
-
-      context "when the camera has been zoomed in" do
-        before { renderer.camera.zoom = 1 }
-
-        it "renders the map larger" do
-          expect_output(array_including(hash_including(
-            w: be > map.pixelwidth, h: be > map.pixelheight,
-            path: :"map_layer_#{layer.id}"
-          )))
-        end
-
-        it "shifts the camera inward" do
-          expect_output(array_including(hash_including(
-            x: be < -renderer.camera.x, y: be < -renderer.camera.y,
-            path: :"map_layer_#{layer.id}"
-          )))
-        end
-      end
-
-      context "when the camera has been zoomed out" do
-        before { renderer.camera.zoom = -1 }
-
-        it "renders the map smaller" do
-          expect_output(array_including(hash_including(
-            w: be < map.pixelwidth, h: be < map.pixelheight,
-            path: :"map_layer_#{layer.id}"
-          )))
-        end
-
-        it "shifts the camera outward" do
-          expect_output(array_including(hash_including(
-            x: be > -renderer.camera.x, y: be > -renderer.camera.y,
-            path: :"map_layer_#{layer.id}"
-          )))
+          expect_output(array_including(hash_including(x: -renderer.camera.x, y: -renderer.camera.y,
+                                                       w: map.pixelwidth, h: map.pixelheight,
+                                                       path: :"map_layer_#{layer.id}")))
         end
       end
     end

--- a/spec/tiled_renderer/renderer_spec.rb
+++ b/spec/tiled_renderer/renderer_spec.rb
@@ -96,6 +96,53 @@ describe Tiled::Renderer do
         expect_output(array_including(hash_including(x: 0, y: 0,
           w: map.pixelwidth, h: map.pixelheight, path: :"map_layer_#{layer.id}")))
       end
+
+      context "when the camera position has been adjusted" do
+        before { renderer.camera.zoom }
+
+        it "draws the layer as a map-sized sprite" do
+          expect_output(array_including(hash_including(
+            x: -renderer.camera.x, y: -renderer.camera.y,
+            w: map.pixelwidth, h: map.pixelheight, path: :"map_layer_#{layer.id}"
+          )))
+        end
+      end
+
+      context "when the camera has been zoomed in" do
+        before { renderer.camera.zoom = 1 }
+
+        it "renders the map larger" do
+          expect_output(array_including(hash_including(
+            w: be > map.pixelwidth, h: be > map.pixelheight,
+            path: :"map_layer_#{layer.id}"
+          )))
+        end
+
+        it "shifts the camera inward" do
+          expect_output(array_including(hash_including(
+            x: be < -renderer.camera.x, y: be < -renderer.camera.y,
+            path: :"map_layer_#{layer.id}"
+          )))
+        end
+      end
+
+      context "when the camera has been zoomed out" do
+        before { renderer.camera.zoom = -1 }
+
+        it "renders the map smaller" do
+          expect_output(array_including(hash_including(
+            w: be < map.pixelwidth, h: be < map.pixelheight,
+            path: :"map_layer_#{layer.id}"
+          )))
+        end
+
+        it "shifts the camera outward" do
+          expect_output(array_including(hash_including(
+            x: be > -renderer.camera.x, y: be > -renderer.camera.y,
+            path: :"map_layer_#{layer.id}"
+          )))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Zooms in/out and stays centered, but the edge collisions for panning up or to the right are off if any zoom has been applied:

https://github.com/vinnydiehl/drtiled-renderer/assets/1045694/98d38904-b2a2-4ce1-af5e-34c46de7643c

The offset is calculated like so:
![zoom offset logic](https://github.com/vinnydiehl/drtiled-renderer/assets/1045694/0e9db611-1137-4df9-a350-955e502ad24b)

The map's `x`, `y`, `w`, and `h` are shifted by these deltas (there is a separate aspect ratio calculation to get ΔW and ΔH). ΔCx and ΔCy are saved to the `Camera` as `@zoom_offset`.

`Camera#move` attempts to clamp the position to the edges at e.g. `-@zoom_offset.x` and `@map_width - @screen_width + @zoom_offset.x` for a horizontal motion; this works on the min side (albeit with some jitter), but the max side will require some more math due to scaling.

Checklist for merge:

Goal|Status
--------------------------|:-:
Fix edge collision offsets|✔️
Fix edge collision jitter|✔️
Don't zoom out past edges of map|✔️