### PR TITLE
Fixing warning due to dragonruby update 5.19

### DIFF
--- a/lib/tiledriver/cache.rb
+++ b/lib/tiledriver/cache.rb
@@ -10,6 +10,7 @@ module Tiled
     # @return [GTK::OutputsArray] the primitives input for the render target
     def layer_render_target(target_name)
       @args.render_target(target_name).tap do |t|
+        t.transient = true
         t.clear_before_render = true
         t.width = @map.width * @map.tilewidth
         t.height = @map.height * @map.tileheight


### PR DESCRIPTION
The warning was due to this change that was described in the log as described here:

** [Bugfix] Removed divergent behavior of web builds which marked render_targets as ~transient!~ by default.
   Render targets by default are cached by DragonRuby. This allows for the texture to be reconstituted
   in the event a window is resized. If the render target you are creating it updated every frame, it's
   important to mark the render_target as ~transient~ (you'll get a warning recommending to do this if we
   detect consequtive updates to a render target).